### PR TITLE
Updated key/nonce/export_secret info strings to current spec

### DIFF
--- a/hpke.go
+++ b/hpke.go
@@ -147,17 +147,17 @@ type contextParameters struct {
 }
 
 func (cp contextParameters) aeadKey() []byte {
-	context := append([]byte("hpke key"), cp.context...)
+	context := append([]byte("key"), cp.context...)
 	return cp.suite.KDF.Expand(cp.secret, context, cp.suite.AEAD.KeySize())
 }
 
 func (cp contextParameters) exporterSecret() []byte {
-	context := append([]byte("hpke exp"), cp.context...)
+	context := append([]byte("exp"), cp.context...)
 	return cp.suite.KDF.Expand(cp.secret, context, cp.suite.KDF.OutputSize())
 }
 
 func (cp contextParameters) aeadNonce() []byte {
-	context := append([]byte("hpke nonce"), cp.context...)
+	context := append([]byte("nonce"), cp.context...)
 	return cp.suite.KDF.Expand(cp.secret, context, cp.suite.AEAD.NonceSize())
 }
 


### PR DESCRIPTION
The info strings don't have "hpke" in them, since https://github.com/cfrg/draft-irtf-cfrg-hpke/commit/8bbbb3fbe8818dc39a52501e82be232827e84008